### PR TITLE
Fix QAM About version display

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { version } from '../package.json'
+
 export const appTypes = {
   1: 'game',
   2: 'software',
@@ -7,7 +9,7 @@ export const appTypes = {
   65536: 'playtest'
 }
 
-export const PLUGIN_VERSION = '1.3.2'
+export const PLUGIN_VERSION = version
 
 // ProtonDB Gateway configuration
 export const GATEWAY_BASE_URL = 'https://protondb.schelstraete.org'


### PR DESCRIPTION
## Summary

- derive `PLUGIN_VERSION` from `package.json`
- remove the stale duplicate frontend version literal
- keep the existing QAM About consumer unchanged

## Verification

- `pnpm build`
- generated-bundle assertion confirms version `1.3.3` and rejects stale version `1.3.2`
- installed the development ZIP on a Steam Deck and confirmed **ProtonDB Badges → About** shows version `1.3.3`

## Screenshot

![ProtonDB Badges QAM About panel showing Version 1.3.3](https://github.com/user-attachments/assets/bae0fa65-fd66-4fe2-8c5e-140c13c2f61d)

Fixes #5