### PR TITLE
Add an option to show ProtonDB icons only on focus

### DIFF
--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -52,6 +52,7 @@ export default function Index() {
     setShowAnalysisButton,
     setRoundedCorners,
     setShowLibraryIcons,
+    setLibraryIconsOnFocusOnly,
     setLibraryIconPosition,
     loading
   } = useSettings()
@@ -234,6 +235,19 @@ export default function Index() {
             />
           </DeckPanelSectionRow>
         )}
+        {settings.showAnalysisButton !== false &&
+          settings.showLibraryIcons === true && (
+            <DeckPanelSectionRow>
+              <ToggleField
+                label={t('libraryIconsOnFocusOnly')}
+                description={t('libraryIconsOnFocusOnlyDesc')}
+                checked={settings.libraryIconsOnFocusOnly === true}
+                onChange={(checked: boolean) => {
+                  setLibraryIconsOnFocusOnly(checked)
+                }}
+              />
+            </DeckPanelSectionRow>
+          )}
         {settings.showAnalysisButton !== false &&
           settings.showLibraryIcons === true && (
             <DeckPanelSectionRow>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -13,6 +13,7 @@ export type Settings = {
   showAnalysisButton?: boolean
   roundedCorners?: boolean
   showLibraryIcons?: boolean
+  libraryIconsOnFocusOnly?: boolean
   libraryIconPosition?: 'bl' | 'tl' | 'tr'
 }
 
@@ -27,6 +28,7 @@ const DEFAULT_SETTINGS: Settings = {
   showAnalysisButton: true,
   roundedCorners: false,
   showLibraryIcons: true,
+  libraryIconsOnFocusOnly: false,
   libraryIconPosition: 'bl'
 }
 
@@ -117,6 +119,12 @@ export const useSettings = () => {
     updateSettings('showLibraryIcons', value)
   }
 
+  function setLibraryIconsOnFocusOnly(
+    value: Settings['libraryIconsOnFocusOnly']
+  ) {
+    updateSettings('libraryIconsOnFocusOnly', value)
+  }
+
   function setLibraryIconPosition(value: Settings['libraryIconPosition']) {
     updateSettings('libraryIconPosition', value)
   }
@@ -133,6 +141,7 @@ export const useSettings = () => {
     setShowAnalysisButton,
     setRoundedCorners,
     setShowLibraryIcons,
+    setLibraryIconsOnFocusOnly,
     setLibraryIconPosition,
     loading
   }

--- a/src/localisation/en.json
+++ b/src/localisation/en.json
@@ -110,6 +110,8 @@
     "roundedCornersDesc": "Use rounded corners on all badge buttons",
     "showLibraryIcons": "Library Status Icons",
     "showLibraryIconsDesc": "Show compatibility status icons on game covers in the library grid",
+    "libraryIconsOnFocusOnly": "Show icons only when game is focused",
+    "libraryIconsOnFocusOnlyDesc": "Show status icons only while a game has controller or keyboard focus, or mouse hover",
     "libraryIconPosition": "Icon Position",
     "libraryIconPositionDesc": "Position of the status icon on game covers",
     "clearCacheSuccess": "Cache cleared successfully",

--- a/src/patches/LibraryGridPatch.ts
+++ b/src/patches/LibraryGridPatch.ts
@@ -122,10 +122,12 @@ function syncFocusOnlyStyle(
   if (!bpDoc) return
 
   const existing = bpDoc.getElementById(FOCUS_ONLY_STYLE_ID)
-  if (
-    SettingsContext.value.showLibraryIcons !== true ||
-    SettingsContext.value.libraryIconsOnFocusOnly !== true
-  ) {
+  if (SettingsContext.value.showLibraryIcons !== true) {
+    existing?.remove()
+    for (const dot of bpDoc.querySelectorAll(`.${DOT_CLASS}`)) dot.remove()
+    return
+  }
+  if (SettingsContext.value.libraryIconsOnFocusOnly !== true) {
     existing?.remove()
     return
   }
@@ -584,7 +586,9 @@ export function initLibraryGridPatch(): () => void {
 
   return () => {
     settingsSubscription.unsubscribe()
-    getBigPictureDocument()?.getElementById(FOCUS_ONLY_STYLE_ID)?.remove()
+    const bpDoc = getBigPictureDocument()
+    bpDoc?.getElementById(FOCUS_ONLY_STYLE_ID)?.remove()
+    for (const dot of bpDoc?.querySelectorAll(`.${DOT_CLASS}`) ?? []) dot.remove()
     if (scanInterval) {
       clearInterval(scanInterval)
       scanInterval = null

--- a/src/patches/LibraryGridPatch.ts
+++ b/src/patches/LibraryGridPatch.ts
@@ -16,6 +16,7 @@ const SCAN_INTERVAL_MS = 3000
 const GRID_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 const DOT_CLASS = 'protondb-grid-dot'
 const COVER_SELECTOR = '._1pwP4eeP1zQD7PEgmsep0W'
+const FOCUS_ONLY_STYLE_ID = 'protondb-grid-focus-only'
 const APP_ID_FROM_SRC = /\/(?:assets|customimages)\/(\d+)/
 
 const STATUS_COLORS: Record<string, string> = {
@@ -113,6 +114,32 @@ function getBigPictureDocument(): Document | null {
   } catch {
     return null
   }
+}
+
+function syncFocusOnlyStyle(
+  bpDoc: Document | null = getBigPictureDocument()
+) {
+  if (!bpDoc) return
+
+  const existing = bpDoc.getElementById(FOCUS_ONLY_STYLE_ID)
+  if (
+    SettingsContext.value.showLibraryIcons !== true ||
+    SettingsContext.value.libraryIconsOnFocusOnly !== true
+  ) {
+    existing?.remove()
+    return
+  }
+  if (existing) return
+
+  const style = bpDoc.createElement('style')
+  style.id = FOCUS_ONLY_STYLE_ID
+  style.textContent = `
+${COVER_SELECTOR} .${DOT_CLASS} { opacity: 0; }
+${COVER_SELECTOR}.gpfocuswithin .${DOT_CLASS},
+${COVER_SELECTOR}:focus-within .${DOT_CLASS},
+${COVER_SELECTOR}:hover .${DOT_CLASS} { opacity: 1; }
+`
+  bpDoc.head.appendChild(style)
 }
 
 async function fetchWithTimeout(
@@ -341,6 +368,7 @@ async function scanTiles() {
 
     const bpDoc = getBigPictureDocument()
     if (!bpDoc) return
+    syncFocusOnlyStyle(bpDoc)
 
     const covers = bpDoc.querySelectorAll(COVER_SELECTOR)
     const needsDiskCheck: Array<{ rawId: string; cover: Element }> = []
@@ -531,6 +559,10 @@ async function prefetchLibrary() {
 export function initLibraryGridPatch(): () => void {
   console.log('[ProtonDB Grid] Initializing library grid patch')
 
+  const settingsSubscription = SettingsContext.subscribe(() =>
+    syncFocusOnlyStyle()
+  )
+
   reinjectInterval = setInterval(reinjectCached, 1000)
 
   prefetchAborted = false
@@ -551,6 +583,8 @@ export function initLibraryGridPatch(): () => void {
     })
 
   return () => {
+    settingsSubscription.unsubscribe()
+    getBigPictureDocument()?.getElementById(FOCUS_ONLY_STYLE_ID)?.remove()
     if (scanInterval) {
       clearInterval(scanInterval)
       scanInterval = null


### PR DESCRIPTION
## Related issue

Implements https://github.com/bschelst/protondb-decky/issues/7

## What this changes

This adds a new **Show icons only when game is focused** option under **Library Status Icons**.

When this option is on, ProtonDB icons appear when a game is:

- selected with a controller or keyboard
- pointed at with a mouse

The option works in both the Home game row and the Library. It is off by default, so current users keep the same experience unless they choose to turn it on.

## Why this is useful

Library icons are helpful, but showing one on every game can make the screen feel busy. This option keeps the icons available while giving users a cleaner Home and Library view.

## Screenshots

### New setting

<img width="690" height="861" alt="focus-only-setting" src="https://github.com/user-attachments/assets/76c3750c-9026-4b02-8c00-b0631418a1e5" />

### Home

Only the selected game shows its ProtonDB icon.

<img width="1024" height="640" alt="home-focused-icon" src="https://github.com/user-attachments/assets/9e80471b-580b-4ae8-93dd-3f90b21e1e03" />



### Library

The icon follows the selected game as the user moves through the Library.

<img width="1024" height="640" alt="library-focused-icon" src="https://github.com/user-attachments/assets/698bbdb0-db8a-482a-8a2d-0112de96b4aa" />


## What I checked

- Existing users keep the current always-visible icons by default.
- The new option works with controller and keyboard selection.
- Mouse hover also shows the icon.
- The option takes effect as soon as it is changed.
- Home and Library both use the same behavior.
- Turning Library Status Icons off removes the icons cleanly.
